### PR TITLE
Gacha Simulator UI Enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
             "version": "0.0.0",
             "dependencies": {
                 "bootstrap": "^5.3.3",
+                "chart.js": "^4.4.8",
                 "esbuild": ">=0.25.0",
                 "jsonschema": "^1.5.0",
                 "pinia": "^2.3.1",
                 "vue": "^3.5.13",
+                "vue-chartjs": "^5.3.2",
                 "vue-router": "^4.5.0"
             },
             "devDependencies": {
@@ -1401,6 +1403,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2929,6 +2937,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+            "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/check-error": {
@@ -7162,6 +7182,16 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue-chartjs": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+            "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "vue": "^3.0.0-0 || ^2.7.0"
             }
         },
         "node_modules/vue-component-type-helpers": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     },
     "dependencies": {
         "bootstrap": "^5.3.3",
+        "chart.js": "^4.4.8",
         "esbuild": ">=0.25.0",
         "jsonschema": "^1.5.0",
         "pinia": "^2.3.1",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.2",
         "vue-router": "^4.5.0"
     },
     "devDependencies": {

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -73,6 +73,10 @@ const allElites = processedSupply.dolls.elites.concat(processedSupply.weapons.el
 const allStandards = processedSupply.dolls.standards.concat(processedSupply.weapons.standards)
 const pulls = usePullsStore()
 
+const showElites = ref(true)
+const showStandards = ref(true)
+const showRetired = ref(true)
+
 // Methods
 /**
  * Determines whether it's the first time any of the given results have been pulled. If so, get the
@@ -264,14 +268,26 @@ function handleMulti() {
                     </div>
                     <div class="container-fluid h-100 p-0">
                         <div class="container-fluid" v-for="(pull, i) in [...pulls.pulls].reverse()">
-                            <div :class="['row border-bottom border-secondary py-1',
-                                isElite(pull.name) ? 'bg-elite' : '',
-                                isStandard(pull.name) ? 'bg-standard' : '']">
+                            <div v-if="(isElite(pull.name) && showElites) || (isStandard(pull.name) && showStandards) || (pull.name.startsWith('Retired') && showRetired)"
+                                :class="['row border-bottom border-secondary py-1',
+                                    isElite(pull.name) ? 'bg-elite' : '',
+                                    isStandard(pull.name) ? 'bg-standard' : '']">
                                 <div class="col-3">{{ pulls.pulls.length - i }}</div>
                                 <div class="col-6">{{ pull.name }}</div>
                                 <div class="col-3" v-if="isElite(pull.name)">Pity: {{ pull.pity }}</div>
                             </div>
                         </div>
+                    </div>
+                    <div class="container-fluid py-2 position-sticky bottom-0 bg-light d-flex justify-content-center border-secondary border">
+                        <button class="btn bg-elite" :class="showElites ? 'bg-elite' : 'bg-secondary'" @click="showElites = !showElites">
+                            Elites
+                        </button>
+                        <button class="btn ms-2 bg-standard" :class="showStandards ? 'bg-standard' : 'bg-secondary'" @click="showStandards = !showStandards">
+                            Standards
+                        </button>
+                        <button class="btn ms-2" :class="showRetired ? 'bg-primary' : 'bg-secondary'" @click="showRetired = !showRetired">
+                            Retired
+                        </button>
                     </div>
                 </div>
             </div>
@@ -289,8 +305,8 @@ function handleMulti() {
                         </div>
                     </div>
                     <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2">
-                        <button class="btn btn-secondary" @click="handleSingle">Pull</button>
-                        <button class="btn btn-secondary ms-2" @click="handleMulti">Pull x10</button>
+                        <button class="btn btn-secondary bg-primary one-pull" @click="handleSingle">Pull</button>
+                        <button class="btn btn-secondary ms-2 ten-pull" @click="handleMulti">Pull x10</button>
                     </div>
                 </div>
             </div>
@@ -304,11 +320,11 @@ button {
     border-radius: 2px;
 }
 
-button:first-child {
+.one-pull {
     background-color: #c0b4bc;
 }
 
-button:nth-child(2) {
+.ten-pull {
     background-color: #e04414;
 }
 

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -305,7 +305,7 @@ function handleMulti() {
                         </div>
                     </div>
                     <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2">
-                        <button class="btn btn-secondary bg-primary one-pull" @click="handleSingle">Pull</button>
+                        <button class="btn btn-secondary one-pull" @click="handleSingle">Pull</button>
                         <button class="btn btn-secondary ms-2 ten-pull" @click="handleMulti">Pull x10</button>
                     </div>
                 </div>

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -100,12 +100,12 @@ function checkFirstTime(results: string[]) {
  * so this can be considered to be a 99%
  * - 75 - 58 = 17 with a rate difference from 99 - 0.6 = 98.4, so 98.4 / 17 = 5.788 increase per
  * pull
- * 
+ *
  * - Base standard rate is 6% (3% for dolls and 3% for weapons)
  * - Standard rate has to be taken as elite + standard rates because otherwise any random value
- * below the elite rate wouldn't be part of the standard rate (so it would effectively be 
+ * below the elite rate wouldn't be part of the standard rate (so it would effectively be
  * standard - elite)
- * 
+ *
  * - Rate for blue trash is 93.4% with the rate shared equally between all trash
  */
 function doSinglePull() {
@@ -201,6 +201,7 @@ function showVideo(type: number) {
  */
 function handleSingle() {
     const result = doSinglePull()
+    const pity = pulls.count + 1
 
     pulls.increaseCount()
 
@@ -217,7 +218,7 @@ function handleSingle() {
     }
 
     checkFirstTime([result])
-    pulls.addPulls(result)
+    pulls.addPulls({ name: result, pity: pity })
 }
 
 /**
@@ -226,6 +227,7 @@ function handleSingle() {
 function handleMulti() {
     const results = Array(10).fill(0).map(() => {
         const result = doSinglePull()
+        const pity = pulls.count + 1
 
         pulls.increaseCount()
 
@@ -241,11 +243,11 @@ function handleMulti() {
             pulls.increaseStandards()
         }
 
-        return result
+        return { name: result, pity: pity}
     })
 
-    checkFirstTime(results)
-    pulls.addPulls(results.flat())
+    checkFirstTime(results.map(r => r.name))
+    pulls.addPulls(results)
 }
 </script>
 
@@ -263,10 +265,11 @@ function handleMulti() {
                     <div class="container-fluid h-100 p-0">
                         <div class="container-fluid" v-for="(pull, i) in [...pulls.pulls].reverse()">
                             <div :class="['row border-bottom border-secondary py-1',
-                                isElite(pull) ? 'bg-elite' : '',
-                                isStandard(pull) ? 'bg-standard' : '']">
+                                isElite(pull.name) ? 'bg-elite' : '',
+                                isStandard(pull.name) ? 'bg-standard' : '']">
                                 <div class="col-3">{{ pulls.pulls.length - i }}</div>
-                                <div class="col-9">{{ pull }}</div>
+                                <div class="col-6">{{ pull.name }}</div>
+                                <div class="col-3" v-if="isElite(pull.name)">Pity: {{ pull.pity }}</div>
                             </div>
                         </div>
                     </div>

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { Modal } from "bootstrap"
-import { ref } from "vue"
+import { ref, computed } from "vue"
+import { Pie } from 'vue-chartjs'
+import { Chart as ChartJS, Title, Tooltip, Legend, ArcElement, CategoryScale } from 'chart.js'
+
+ChartJS.register(Title, Tooltip, Legend, ArcElement, CategoryScale)
 
 import banner from "@/assets/images/banner.png"
 import supply from "@/assets/data/gacha-db.json"
@@ -8,6 +12,7 @@ import supply from "@/assets/data/gacha-db.json"
 import { getRandomElement } from "@/utils/array"
 import { usePullsStore } from "@/stores/pulls"
 import FullScreenVideoModal from "@/components/FullScreenVideoModal.vue"
+import { Interaction } from "chart.js"
 
 interface GachaCategory {
     elites: string[],
@@ -253,6 +258,33 @@ function handleMulti() {
     checkFirstTime(results.map(r => r.name))
     pulls.addPulls(results)
 }
+
+const pieData = computed(() => {
+  return {
+    labels: ['Elites', 'Standards', 'Retired'],
+    datasets: [
+      {
+        data: [pulls.elites, pulls.standards, pulls.total - pulls.elites - pulls.standards],
+        backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56'],
+        hoverBackgroundColor: ['#FF6384', '#36A2EB', '#FFCE56']
+      }
+    ]
+  }
+})
+
+const pieOptions = {
+  plugins: {
+    legend: {
+      display: false
+    },
+    tooltips: {
+      enabled: true,
+    }
+  },
+  interaction: {
+    mode: 'dataset',
+  }
+}
 </script>
 
 <template>
@@ -261,10 +293,16 @@ function handleMulti() {
         <div class="row">
             <div class="col-md-4 p-0 border border-secondary overflow-y-scroll pull-log order-1 order-md-0">
                 <div class="d-flex flex-column h-100">
-                    <div
-                      class="container-fluid d-flex justify-space-between text-bg-success py-2 border-bottom border-secondary position-sticky top-0">
-                      <span>Current: {{ pulls.count }} (Pity: {{ pulls.pity ? "✓" : "✘" }})</span>
-                      <span class="ms-auto">Total: {{ pulls.total }}</span>
+                    <div class="container-fluid py-2 position-sticky bottom-0 bg-light d-flex justify-content-center border-secondary border">
+                        <button class="btn bg-elite" :class="showElites ? 'bg-elite' : 'bg-secondary'" @click="showElites = !showElites">
+                            Elites
+                        </button>
+                        <button class="btn ms-2 bg-standard" :class="showStandards ? 'bg-standard' : 'bg-secondary'" @click="showStandards = !showStandards">
+                            Standards
+                        </button>
+                        <button class="btn ms-2" :class="showRetired ? 'bg-primary' : 'bg-secondary'" @click="showRetired = !showRetired">
+                            Retired
+                        </button>
                     </div>
                     <div class="container-fluid h-100 p-0">
                         <div class="container-fluid" v-for="(pull, i) in [...pulls.pulls].reverse()">
@@ -278,36 +316,38 @@ function handleMulti() {
                             </div>
                         </div>
                     </div>
-                    <div class="container-fluid py-2 position-sticky bottom-0 bg-light d-flex justify-content-center border-secondary border">
-                        <button class="btn bg-elite" :class="showElites ? 'bg-elite' : 'bg-secondary'" @click="showElites = !showElites">
-                            Elites
-                        </button>
-                        <button class="btn ms-2 bg-standard" :class="showStandards ? 'bg-standard' : 'bg-secondary'" @click="showStandards = !showStandards">
-                            Standards
-                        </button>
-                        <button class="btn ms-2" :class="showRetired ? 'bg-primary' : 'bg-secondary'" @click="showRetired = !showRetired">
-                            Retired
-                        </button>
-                    </div>
                 </div>
             </div>
             <div class="col-md-8 p-0 border border-secondary order-0 order-md-1">
                 <img class="img-fluid" :src="banner" alt="Current banner">
                 <div class="container-fluid d-flex flex-column flex-md-row">
+                  <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2">
                     <div class="container-fluid">
-                        <div class="container d-flex justify-content-between">
-                            <span>Elites: {{ pulls.elites }}</span>
-                            <span>{{ (pulls.elites / pulls.total * 100 || 0).toFixed(2) }}% of total pulls</span>
-                        </div>
-                        <div class="container d-flex justify-content-between">
-                            <span>Standards: {{ pulls.standards }}</span>
-                            <span>{{ (pulls.standards / pulls.total * 100 || 0).toFixed(2) }}% of total pulls</span>
-                        </div>
+                      <div class="container d-flex justify-content-between">
+                          <span>Total: </span>
+                          <span>{{ pulls.total }}</span>
+                      </div>
+                      <div class="container d-flex justify-content-between">
+                          <span>Elites: </span>
+                          <span>{{ pulls.elites }} ({{ (pulls.elites / pulls.total * 100 || 0).toFixed(2) }}%)</span>
+                      </div>
+                      <div class="container d-flex justify-content-between">
+                          <span>Standards: </span>
+                          <span>{{ pulls.standards }} ({{ (pulls.standards / pulls.total * 100 || 0).toFixed(2) }}%)</span>
+                      </div>
+                      <div class="container d-flex justify-content-between">
+                          <span>Current Pity: </span>
+                          <span>{{ pulls.count }} (Pity: {{ pulls.pity ? "✓" : "✘" }})</span>
+                      </div>
                     </div>
-                    <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2">
-                        <button class="btn btn-secondary one-pull" @click="handleSingle">Pull</button>
-                        <button class="btn btn-secondary ms-2 ten-pull" @click="handleMulti">Pull x10</button>
+                    <div class="container-fluid" style="max-width: 120px; margin: auto;">
+                      <Pie :data="pieData" :options="pieOptions" />
                     </div>
+                  </div>
+                  <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2 height-100">
+                      <button class="btn btn-secondary one-pull" @click="handleSingle">Pull</button>
+                      <button class="btn btn-secondary ms-2 ten-pull" @click="handleMulti">Pull x10</button>
+                  </div>
                 </div>
             </div>
         </div>
@@ -318,6 +358,7 @@ function handleMulti() {
 button {
     width: 150px;
     border-radius: 2px;
+    height: 40px;
 }
 
 .one-pull {

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -258,9 +258,9 @@ function handleMulti() {
             <div class="col-md-4 p-0 border border-secondary overflow-y-scroll pull-log order-1 order-md-0">
                 <div class="d-flex flex-column h-100">
                     <div
-                        class="container-fluid d-flex justify-space-between text-bg-success py-2 border-bottom border-secondary">
-                        <span>Current: {{ pulls.count }} (Pity: {{ pulls.pity ? "✓" : "✘" }})</span>
-                        <span class="ms-auto">Total: {{ pulls.total }}</span>
+                      class="container-fluid d-flex justify-space-between text-bg-success py-2 border-bottom border-secondary position-sticky top-0">
+                      <span>Current: {{ pulls.count }} (Pity: {{ pulls.pity ? "✓" : "✘" }})</span>
+                      <span class="ms-auto">Total: {{ pulls.total }}</span>
                     </div>
                     <div class="container-fluid h-100 p-0">
                         <div class="container-fluid" v-for="(pull, i) in [...pulls.pulls].reverse()">


### PR DESCRIPTION
## Summary
This pull request introduces several new features and enhancements to the Gacha Simulator:

1. **Pity Counter**: Added a counter to track the current pity status.
2. **Toggle Visibility Buttons**: Added buttons to toggle the visibility of Elites, Standards, and Retired pulls.
3. **Pie Chart**: Integrated a pie chart to visually represent the distribution of Elites, Standards, and Retired pulls.

## Detailed Changes

- **Pity Counter**:
   - Implemented a counter to display the current pity status in the pull log.
   - Updated the `handleSingle` and `handleMulti` methods to reset and update the pity counter accordingly.
   
- **Toggle Visibility Buttons**:
   - Added buttons to toggle the visibility of Elites, Standards, and Retired pulls.
   - Updated the template to conditionally render pulls based on the visibility state.

- **Pie Chart**:
   - Integrated `vue-chartjs` and `chart.js` libraries to display a pie chart.
   - Configured the pie chart to show the distribution of Elites, Standards, and Retired pulls.
   - Updated the `pieOptions` to show all detailed values at once when hovering over the chart.

## Library Changes
Added `vue-chartjs` and `chart.js` libraries to the project for chart visualization.

## Screenshots
![image](https://github.com/user-attachments/assets/804f1a14-f89e-4139-a53a-cf966e32e2cb)

##Testing
- Tested the new features manually to ensure they work as expected.
- Verified that the pie chart displays accurate data and updates in real-time.

Additional Notes
Ensure to run `npm install` to include the new libraries before testing the changes.

