### PR TITLE
Fixed the issue where pity counter is not saved to local storage

### DIFF
--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -83,6 +83,9 @@ const showElites = ref(true)
 const showStandards = ref(true)
 const showRetired = ref(true)
 
+// Constants
+const MAX_PULLS = 1000
+
 // Load pulls and pity counter from localStorage
 onMounted(() => {
     const savedPulls = localStorage.getItem('gachaPulls')
@@ -111,6 +114,16 @@ watch(() => pulls.count, (newCount) => {
 })
 
 // Methods
+/**
+ * Shifts the saved pulls if the limit is reached.
+ */
+function shiftPullsIfNeeded() {
+    if (pulls.pulls.length > MAX_PULLS) {
+        pulls.pulls = pulls.pulls.slice(pulls.pulls.length - MAX_PULLS)
+        localStorage.setItem('gachaPulls', JSON.stringify(pulls.pulls))
+    }
+}
+
 /**
  * Determines whether it's the first time any of the given results have been pulled. If so, get the
  * rarity and play the corresponding movie file in an overlay.
@@ -265,6 +278,7 @@ function handleSingle() {
 
     checkFirstTime([result])
     pulls.addPulls({ name: result, pity: pity })
+    shiftPullsIfNeeded() // Shift pulls if needed
     localStorage.setItem('gachaPulls', JSON.stringify(pulls.pulls)) // Save to localStorage
 }
 
@@ -295,6 +309,7 @@ function handleMulti() {
 
     checkFirstTime(results.map(r => r.name))
     pulls.addPulls(results)
+    shiftPullsIfNeeded() // Shift pulls if needed
     localStorage.setItem('gachaPulls', JSON.stringify(pulls.pulls)) // Save to localStorage
 }
 

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -83,9 +83,10 @@ const showElites = ref(true)
 const showStandards = ref(true)
 const showRetired = ref(true)
 
-// Load pulls from localStorage
+// Load pulls and pity counter from localStorage
 onMounted(() => {
     const savedPulls = localStorage.getItem('gachaPulls')
+    const savedPityCounter = localStorage.getItem('gachaPityCounter')
     if (savedPulls) {
         pulls.addPulls(JSON.parse(savedPulls))
         // Update the chart and text
@@ -95,14 +96,19 @@ onMounted(() => {
         pulls.count = pulls.pulls.length ? pulls.pulls[pulls.pulls.length - 1].pity : 0
         pulls.pity = pulls.pulls.length ? isElite(pulls.pulls[pulls.pulls.length - 1].name) : false
     }
+    if (savedPityCounter) {
+        pulls.count = JSON.parse(savedPityCounter)
+    }
 })
 
-// Watch for changes in pulls and save to localStorage
+// Watch for changes in pulls and pity counter, and save to localStorage
 watch(() => pulls.pulls, (newPulls) => {
     localStorage.setItem('gachaPulls', JSON.stringify(newPulls))
 }, { deep: true })
 
-
+watch(() => pulls.count, (newCount) => {
+    localStorage.setItem('gachaPityCounter', JSON.stringify(newCount))
+})
 
 // Methods
 /**
@@ -227,11 +233,12 @@ function showVideo(type: number) {
 }
 
 /**
- * Resets the saved pulls.
+ * Resets the saved pulls and pity counter.
  */
 function resetPulls() {
     pulls.$reset()
     localStorage.removeItem('gachaPulls')
+    localStorage.removeItem('gachaPityCounter')
 }
 
 // Event handlers


### PR DESCRIPTION
Added the feature to save the pity counter to local storage so it is saved between sessions. Also added a feature to shift the data if it reaches above 1000. Though I couldn't replicate the problem with the pie label, because the label is gone whenever the pie data is not present (therefore the pie chart is not visible too).