### PR TITLE
Modal for rolled items, and redesigned team builder view for mobile

### DIFF
--- a/src/components/DollFigure.vue
+++ b/src/components/DollFigure.vue
@@ -14,12 +14,14 @@ const props = withDefaults(
         selectedTeam?: number
         supportTeams?: number[]
         teams?: number[]
+        displayText?: boolean
     }>(),
     {
         select: false,
         selectedTeam: 0,
         supportTeams: () => [],
         teams: () => [],
+        displayText: true,
     },
 )
 
@@ -53,8 +55,8 @@ const supportBadgeClasses = computed(() => {
         <span v-if="dupe" :class="['badge rounded-pill position-absolute top-0 end-0', supportBadgeClasses]">
             V {{ dupe }}
         </span>
-        <figcaption class="figure-caption text-center user-select-none text-wrap w-100">
-            {{ doll || "&nbsp;" }}
+        <figcaption v-if="displayText" class="figure-caption text-center user-select-none text-wrap w-100">
+            {{ doll || "\u00A0" }}
         </figcaption>
     </figure>
 </template>

--- a/src/components/DollFigure.vue
+++ b/src/components/DollFigure.vue
@@ -52,8 +52,8 @@ const supportBadgeClasses = computed(() => {
         <span v-if="isSupport" :class="['badge rounded-pill position-absolute top-0 end-0', supportBadgeClasses]">
             S
         </span>
-        <span v-if="dupe" :class="['badge rounded-pill position-absolute top-0 end-0', supportBadgeClasses]">
-            V {{ dupe }}
+        <span v-if="dupe" :class="['badge rounded-pill position-absolute top-0 end-0 text-bg-primary']">
+            V{{ dupe }}
         </span>
         <figcaption v-if="displayText" class="figure-caption text-center user-select-none text-wrap w-100">
             {{ doll || "\u00A0" }}

--- a/src/components/DollFigure.vue
+++ b/src/components/DollFigure.vue
@@ -7,6 +7,7 @@ const props = withDefaults(
     defineProps<{
         doll: string
         dollsToPaths: { [x: string]: string },
+        dupe?:number
         index?: number
         isSupport?: boolean
         select?: boolean
@@ -49,7 +50,10 @@ const supportBadgeClasses = computed(() => {
         <span v-if="isSupport" :class="['badge rounded-pill position-absolute top-0 end-0', supportBadgeClasses]">
             S
         </span>
-        <figcaption class="d-none d-md-block figure-caption text-center user-select-none">
+        <span v-if="dupe" :class="['badge rounded-pill position-absolute top-0 end-0', supportBadgeClasses]">
+            V {{ dupe }}
+        </span>
+        <figcaption class="figure-caption text-center user-select-none text-wrap w-100">
             {{ doll || "&nbsp;" }}
         </figcaption>
     </figure>
@@ -66,6 +70,7 @@ figure>img {
 
 figure>figcaption {
     cursor: pointer;
+    font-size: clamp(0.7em, 2vw, 1em);
 }
 
 .badge.rounded-circle {

--- a/src/components/RollsModal.vue
+++ b/src/components/RollsModal.vue
@@ -8,8 +8,8 @@
         </div>
         <div class="modal-body">
             <div class="row">
-              <div v-for="(item, count) in rolledItems" :key="item" class="col-4 text-center">
-                <DollFigure :doll="item" :dollsToPaths="dollsToPaths" :dupe="count - 1"></DollFigure>
+              <div v-for="(count, item) in rolledItems" :key="item" class="col-4 text-center">
+                <DollFigure :doll="item.toString()" :dollsToPaths="dollsToPaths" :dupe="count - 1"></DollFigure>
               </div>
             </div>
         </div>

--- a/src/components/RollsModal.vue
+++ b/src/components/RollsModal.vue
@@ -8,7 +8,7 @@
         </div>
         <div class="modal-body">
             <div class="row">
-              <div v-for="(count, item) in rolledItems" :key="item" class="col-4 text-center">
+              <div v-for="(item, count) in rolledItems" :key="item" class="col-4 text-center">
                 <DollFigure :doll="item" :dollsToPaths="dollsToPaths" :dupe="count - 1"></DollFigure>
               </div>
             </div>
@@ -55,9 +55,17 @@ const dollsToPaths = dolls.reduce((accumulator, doll, i) => {
 const pulls = usePullsStore()
 
 const rolledItems = computed(() => {
-  return pulls.pulls.reduce((acc, pull) => {
-    if (!pull.name.includes("Retired")) {
-      acc[pull.name] = (acc[pull.name] || 0) + 1
+  return pulls.pulls.reduce((acc: { [x: string]: any }, pull: { name: string | string[] }) => {
+    if (Array.isArray(pull.name)) {
+      pull.name.forEach(name => {
+        if (!name.includes("Retired")) {
+          acc[name] = (acc[name] || 0) + 1
+        }
+      })
+    } else {
+      if (!pull.name.includes("Retired")) {
+        acc[pull.name] = (acc[pull.name] || 0) + 1
+      }
     }
     return acc
   }, {} as Record<string, number>)

--- a/src/components/RollsModal.vue
+++ b/src/components/RollsModal.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="modal fade" id="rolls-modal" tabindex="-1" aria-labelledby="rollsModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="rollsModalLabel">Rolled Items</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+            <div class="row">
+              <div v-for="(count, item) in rolledItems" :key="item" class="col-4 text-center">
+                <DollFigure :doll="item" :dollsToPaths="dollsToPaths" :dupe="count - 1"></DollFigure>
+              </div>
+            </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { usePullsStore } from '@/stores/pulls'
+import DollFigure from "@/components/DollFigure.vue"
+
+const hyphenatedDollNames = [
+    "Mosin-Nagant"
+]
+
+const files: Record<string, string> = import.meta.glob(
+    "@/assets/images/dolls/*.png",
+    { eager: true, import: "default" },
+)
+const paths = Object.values(files)
+const dolls = paths.map((path: string) => {
+    let doll = path.replace(/^.*[\\/](.+).png$/, "$1")
+
+    for (let i = 0; i < hyphenatedDollNames.length; i++) {
+        if (doll.includes(hyphenatedDollNames[i])) return hyphenatedDollNames[i]
+    }
+
+    doll = doll.replace(/-.*/, "")
+
+    return doll
+})
+const dollsToPaths = dolls.reduce((accumulator, doll, i) => {
+    return Object.assign(accumulator, {
+        [doll]: paths[i]
+    })
+}, {})
+
+const pulls = usePullsStore()
+
+const rolledItems = computed(() => {
+  return pulls.pulls.reduce((acc, pull) => {
+    if (!pull.name.includes("Retired")) {
+      acc[pull.name] = (acc[pull.name] || 0) + 1
+    }
+    return acc
+  }, {} as Record<string, number>)
+})
+</script>
+
+<style scoped>
+.modal-body {
+  max-height: 400px;
+  overflow-y: auto;
+}
+</style>

--- a/src/components/RollsModal.vue
+++ b/src/components/RollsModal.vue
@@ -8,6 +8,7 @@
         </div>
         <div class="modal-body">
             <div class="row">
+              <!-- Loop through rolledItems and display each item -->
               <div v-for="(count, item) in rolledItems" :key="item" class="col-4 text-center">
                 <DollFigure :doll="item.toString()" :dollsToPaths="dollsToPaths" :dupe="count - 1"></DollFigure>
               </div>
@@ -26,34 +27,46 @@ import { computed } from 'vue'
 import { usePullsStore } from '@/stores/pulls'
 import DollFigure from "@/components/DollFigure.vue"
 
+// List of doll names that include hyphens
 const hyphenatedDollNames = [
     "Mosin-Nagant"
 ]
 
+// Import all doll images from the specified directory
 const files: Record<string, string> = import.meta.glob(
     "@/assets/images/dolls/*.png",
     { eager: true, import: "default" },
 )
+
+// Extract paths of the imported images
 const paths = Object.values(files)
+
+// Extract doll names from the image paths
 const dolls = paths.map((path: string) => {
     let doll = path.replace(/^.*[\\/](.+).png$/, "$1")
 
+    // Check if the doll name includes any hyphenated names
     for (let i = 0; i < hyphenatedDollNames.length; i++) {
         if (doll.includes(hyphenatedDollNames[i])) return hyphenatedDollNames[i]
     }
 
+    // Remove any suffix after a hyphen
     doll = doll.replace(/-.*/, "")
 
     return doll
 })
+
+// Create a mapping of doll names to their image paths
 const dollsToPaths = dolls.reduce((accumulator, doll, i) => {
     return Object.assign(accumulator, {
         [doll]: paths[i]
     })
 }, {})
 
+// Access the pulls store
 const pulls = usePullsStore()
 
+// Compute the rolled items from the pulls store
 const rolledItems = computed(() => {
   return pulls.pulls.reduce((acc: { [x: string]: any }, pull: { name: string | string[] }) => {
     if (Array.isArray(pull.name)) {

--- a/src/stores/pulls.ts
+++ b/src/stores/pulls.ts
@@ -6,16 +6,21 @@ export interface Pull {
 }
 
 export const usePullsStore = defineStore("pulls", {
-    state: () => ({
-        count: 0,
-        elites: 0,
-        firstTimes: {} as { [name: string]: boolean },
-        pity: false,
-        pulls: [] as Pull[],
-        standardPity: 0,
-        standards: 0,
-        total: 0,
-    }),
+    state: () => {
+        const savedPulls = localStorage.getItem('hobodrip.gachaPulls')
+        const savedPityCounter = localStorage.getItem('hobodrip.gachaPityCounter')
+
+        return {
+            count: savedPityCounter ? JSON.parse(savedPityCounter) : 0,
+            elites: 0,
+            firstTimes: {} as { [name: string]: boolean },
+            pity: false,
+            pulls: savedPulls ? JSON.parse(savedPulls) : [] as Pull[],
+            standardPity: 0,
+            standards: 0,
+            total: savedPulls ? JSON.parse(savedPulls).length : 0,
+        }
+    },
     actions: {
         addPulls(newPulls: Pull | Pull[]) {
             const intermediary: Pull[] = ([] as Pull[]).concat(newPulls)

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -12,6 +12,7 @@ import supply from "@/assets/data/gacha-db.json"
 import { getRandomElement } from "@/utils/array"
 import { usePullsStore } from "@/stores/pulls"
 import FullScreenVideoModal from "@/components/FullScreenVideoModal.vue"
+import RollsModal from "@/components/RollsModal.vue"
 
 interface GachaCategory {
     elites: string[],
@@ -86,8 +87,11 @@ const showRetired = ref(true)
 // Constants
 const MAX_PULLS = 1000
 
+const rollsModal = ref<InstanceType<typeof Modal> | null>(null)
+
 // Load pulls and pity counter from localStorage
 onMounted(() => {
+    rollsModal.value = new Modal(document.getElementById('rolls-modal')!)
     const savedPulls = localStorage.getItem('gachaPulls')
     const savedPityCounter = localStorage.getItem('gachaPityCounter')
     if (savedPulls) {
@@ -254,6 +258,10 @@ function resetPulls() {
     localStorage.removeItem('gachaPityCounter')
 }
 
+function showRollsModal() {
+    rollsModal.value?.show()
+}
+
 // Event handlers
 /**
  * Handles a single pull.
@@ -343,6 +351,7 @@ const pieOptions = {
 
 <template>
     <FullScreenVideoModal :type="modalVideoType" @hideVideo="hideVideo(0)"></FullScreenVideoModal>
+    <RollsModal></RollsModal>
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-4 p-0 border border-secondary overflow-y-scroll pull-log order-1 order-md-0">
@@ -379,8 +388,11 @@ const pieOptions = {
             <div class="col-md-8 p-0 border border-secondary order-0 order-md-1">
                 <div class="position-relative">
                     <img class="img-fluid" :src="banner" alt="Current banner">
-                    <button class="btn btn-danger m-2 position-absolute bottom-0 start-0" @click="resetPulls"
-                        style="width: 80px;">Reset</button>
+                    <div class="position-absolute bottom-0 start-0">
+                      <button class="btn btn-secondary ms-2" @click="showRollsModal" style="width: 120px;">Show Rolls</button>
+                      <button class="btn btn-danger m-2" @click="resetPulls"
+                      style="width: 80px;">Reset</button>
+                    </div>
                 </div>
                 <div class="container-fluid d-flex flex-column flex-md-row">
                     <div class="container-fluid d-flex justify-content-around justify-content-md-end py-2">

--- a/src/views/GachaSimulator.vue
+++ b/src/views/GachaSimulator.vue
@@ -92,20 +92,6 @@ const rollsModal = ref<InstanceType<typeof Modal> | null>(null)
 // Load pulls and pity counter from localStorage
 onMounted(() => {
     rollsModal.value = new Modal(document.getElementById('rolls-modal')!)
-    const savedPulls = localStorage.getItem('hobodrip.gachaPulls')
-    const savedPityCounter = localStorage.getItem('hobodrip.gachaPityCounter')
-    if (savedPulls) {
-        pulls.addPulls(JSON.parse(savedPulls))
-        // Update the chart and text
-        pulls.total = pulls.pulls.length
-        pulls.elites = pulls.pulls.filter(pull => isElite(pull.name)).length
-        pulls.standards = pulls.pulls.filter(pull => isStandard(pull.name)).length
-        pulls.count = pulls.pulls.length ? pulls.pulls[pulls.pulls.length - 1].pity : 0
-        pulls.pity = pulls.pulls.length ? isElite(pulls.pulls[pulls.pulls.length - 1].name) : false
-    }
-    if (savedPityCounter) {
-        pulls.count = JSON.parse(savedPityCounter)
-    }
 })
 
 // Watch for changes in pulls and pity counter, and save to localStorage
@@ -256,6 +242,14 @@ function resetPulls() {
     pulls.$reset()
     localStorage.removeItem('hobodrip.gachaPulls')
     localStorage.removeItem('hobodrip.gachaPityCounter')
+    pulls.pulls = []
+    pulls.count = 0
+    pulls.elites = 0
+    pulls.standards = 0
+    pulls.total = 0
+    pulls.pity = false
+    pulls.standardPity = 0
+    pulls.firstTimes = {}
 }
 
 function showRollsModal() {

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -210,7 +210,7 @@ function isSupport(doll: string) {
 
           <div class="container-fluid justify-content-end my-2">
               <button class="btn btn-danger me-md-auto w-100" @click="teams.resetSelections">Reset</button>
-              <button class="btn btn-light w-100" data-bs-target="#set-change-modal" data-bs-toggle="modal">Change Set</button>
+              <button class="btn btn-light w-100 my-1" data-bs-target="#set-change-modal" data-bs-toggle="modal">Change Set</button>
               <button class="btn btn-light ms-md-2 w-100" data-bs-target="#import-export-modal" data-bs-toggle="modal">Import/Export</button>
           </div>
       </div>

--- a/src/views/TeamBuilder.vue
+++ b/src/views/TeamBuilder.vue
@@ -240,20 +240,6 @@ function isSupport(doll: string) {
     min-height: 100%;
 }
 
-@media (max-width: 767.98px) {
-    figure>figcaption {
-        display: none;
-    }
-
-    .team-roster button {
-        width: 100%;
-    }
-
-    .team-roster button:not(:first-child) {
-        margin-top: 0.5rem;
-    }
-}
-
 .doll-grid {
   display: grid;
   grid-auto-flow: column;


### PR DESCRIPTION
## Summary
This PR adds:
- Rolled items modal, showing characters that has been pulled (does not save if local storage is reset)
- Redesigned the team builder view for mobile. Temporarily. My brain was burning trying to think of another solution so I just separate PC and mobile view and moved the doll list to the bottom of the screen. Now the list is scrollable horizontally. (Not much of a solution here, maybe I'll redesign it later).
- Doll figure caption now has `clamp` so that it scales according to the viewport width.
- Fixed an issue where loading another component also loads the gacha history. So basically it's doubled whenever you load another page, and then come back to the gacha sim page. 

## Changes: 
- Add `RollsModal.vue` in components.
- Add the button to show the rolls modal in `GachaSimulator.vue`, positioned near the reset button at the bottom left of the banner.
- `pulls.ts` now handles the local storage.
- New args in `DollFigure` so that it can be used for `RollsModal`. 
   - `dupe?: number` : Dupes of the character. Visualized as "V{dupe}", and positioned similar to support badge.
   - `displayText?: boolean` : Self explanatory. Shows figcaption (default is true).
- There are two conditional views in `TeamBuilder.vue`. One is the default, and the other is for narrow viewports.

## Testing:
I made sure there are no red errors in my editor. And the website shows no issue on Pixel 7 and iPhone SE viewports. The team builder is also correctly shown in my Z Fold 6.

## Screenshots:
![image](https://github.com/user-attachments/assets/2c4d3c6c-4747-4608-ad82-dee1391fa9f8)
![image](https://github.com/user-attachments/assets/bf4983f2-80d2-409f-bb7b-560a7aaf12c2)